### PR TITLE
Use '.js.map' as file extension for sourceMapName

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ These properties must be provided if you want to generate source maps.
 ```js
 var result = regexpu.transpileCode(code, {
   'sourceFileName': 'es6.js',
-  'sourceMapName': 'es6.map',
+  'sourceMapName': 'es6.js.map',
 });
 console.log(result.code); // transpiled source code
 console.log(result.map); // source map


### PR DESCRIPTION
SourceMap spec suggest use of `sourceFileName.targetExtension.map` format for sourcemap file.
- https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.txk3vdsh99hf

So I renamed `sourceMapName` in example code.

FYI, CoffeeScript change map filename with the same format.
- [SourceMap: Consistency in map filename · Issue #3297 · jashkenas/coffeescript](https://github.com/jashkenas/coffeescript/issues/3297)

Thanks.
