### PR TITLE
Improve handling of astral symbols in surrogate form

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,17 +55,18 @@
 		"coverage": "istanbul cover --report html node_modules/.bin/_mocha tests/tests.js -- -u exports -R spec"
 	},
 	"dependencies": {
-		"recast": "^0.10.6",
+		"esprima": "^2.6.0",
+		"recast": "^0.10.10",
 		"regenerate": "^1.2.1",
 		"regjsgen": "^0.2.0",
 		"regjsparser": "^0.1.4"
 	},
 	"devDependencies": {
 		"coveralls": "^2.11.2",
-		"istanbul": "^0.3.7",
+		"istanbul": "^0.3.11",
 		"jsesc": "^0.5.0",
-		"lodash": "^3.4.0",
-		"mocha": "^2.2.0",
+		"lodash": "^3.6.0",
+		"mocha": "^2.2.1",
 		"unicode-5.1.0": "^0.1.5",
 		"unicode-7.0.0": "^0.1.5"
 	}

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -107,6 +107,11 @@ var fixtures = [
 		'transpiled': '(?:[a-z]|\\uD834[\\uDF06-\\uDF08])'
 	},
 	{
+		'pattern': '[\\uD834\\uDF06-\\uD834\\uDF08a-z]',
+		'flags': FLAGS_WITH_UNICODE_WITHOUT_I,
+		'transpiled': '(?:[a-z]|\\uD834[\\uDF06-\\uDF08])'
+	},
+	{
 		'pattern': '[\\u{1D306}-\\u{1D308}a-z]',
 		'flags': FLAGS_WITH_UNICODE_WITHOUT_I,
 		'transpiled': '(?:[a-z]|\\uD834[\\uDF06-\\uDF08])'

--- a/transpile-code.js
+++ b/transpile-code.js
@@ -1,3 +1,4 @@
+var esprima = require('esprima');
 var recast = require('recast');
 var transform = require('./transform-tree.js');
 
@@ -7,6 +8,7 @@ module.exports = function(input, options) {
 	var sourceMapName = options.sourceMapName || '';
 	var createSourceMap = sourceFileName && sourceMapName;
 	var tree = recast.parse(input, {
+		'esprima': esprima,
 		'sourceFileName': sourceFileName
 	});
 	tree = transform(tree);


### PR DESCRIPTION
E.g. `/[\uD80C\uDC00-\uD80D\uDC1F]/u` is equivalent to `/[\u{13000}-\u{1342F}]/u` because the surrogate pair form is recognized as a `RegExpUnicodeEscapeSequence` by the RegExp pattern grammar in `U` mode.

Closes #20.